### PR TITLE
Bugfix/error not enough room

### DIFF
--- a/lua/telescope/_extensions/docker/containers/actions.lua
+++ b/lua/telescope/_extensions/docker/containers/actions.lua
@@ -246,7 +246,6 @@ function actions.attach(prompt_bufnr)
     util.warn "Container is not running"
     return
   end
-  util.info("Attaching to container:", container.ID)
   picker.docker_state:docker_command { "attach", container.ID }
 end
 
@@ -263,7 +262,6 @@ function actions.logs(prompt_bufnr)
     return
   end
   local container = selection.value
-  util.info("Fetching logs for container:", container.ID)
   picker.docker_state:docker_command { "logs", container.ID }
 end
 
@@ -284,7 +282,6 @@ function actions.stats(prompt_bufnr)
     util.warn "Container is exited"
     return
   end
-  util.info("Fetching stats for container:", container.ID)
   picker.docker_state:docker_command { "stats", container.ID }
 end
 
@@ -318,7 +315,6 @@ function actions.exec(prompt_bufnr)
     container.ID,
     unpack(vim.split(exec, " ")),
   }
-  util.info("Executing in container:", container.ID)
   picker.docker_state:docker_command(args)
 end
 

--- a/lua/telescope/_extensions/docker/images/actions.lua
+++ b/lua/telescope/_extensions/docker/images/actions.lua
@@ -103,7 +103,6 @@ function actions.history(prompt_bufnr)
   end
   local image = selection.value
   local args = { "image", "history", image.ID }
-  util.info("Fetching history for image:", image.ID)
   picker.docker_state:docker_command(args)
 end
 

--- a/lua/telescope/_extensions/docker/util/docker_state.lua
+++ b/lua/telescope/_extensions/docker/util/docker_state.lua
@@ -67,7 +67,7 @@ function State:docker_command(cmd_args)
       == enum.TELESCOPE_PROMPT_FILETYPE
     then
       local bufnr = vim.api.nvim_get_current_buf()
-      telescope_actions.close(bufnr)
+      pcall(telescope_actions.close, bufnr)
     end
 
     local cmd = { self.binary, unpack(cmd_args) }

--- a/lua/telescope/_extensions/docker/util/docker_state.lua
+++ b/lua/telescope/_extensions/docker/util/docker_state.lua
@@ -3,6 +3,7 @@ local enum = require "telescope._extensions.docker.enum"
 local setup = require "telescope._extensions.docker.setup"
 local Container = require "telescope._extensions.docker.containers.container"
 local Image = require "telescope._extensions.docker.images.image"
+local telescope_actions = require "telescope.actions"
 
 local job_id
 
@@ -65,8 +66,8 @@ function State:docker_command(cmd_args)
       vim.api.nvim_buf_get_option(0, "filetype")
       == enum.TELESCOPE_PROMPT_FILETYPE
     then
-      -- NOTE: close telescope popup if open
-      vim.api.nvim_buf_delete(0, { force = true })
+      local bufnr = vim.api.nvim_get_current_buf()
+      telescope_actions.close(bufnr)
     end
 
     local cmd = { self.binary, unpack(cmd_args) }

--- a/lua/telescope/_extensions/docker/util/popup.lua
+++ b/lua/telescope/_extensions/docker/util/popup.lua
@@ -46,16 +46,21 @@ function create_window(bufnr, height, width)
 end
 
 function handle_window(bufnr, winid, selection_callback)
-  vim.api.nvim_create_autocmd({ "BufEnter", "BufLeave", "FocusLost" }, {
+  vim.api.nvim_create_autocmd({ "BufLeave", "FocusLost" }, {
     buffer = bufnr,
+    once = true,
     callback = function()
-      vim.api.nvim_win_close(winid, true)
-      vim.api.nvim_buf_delete(bufnr, { force = true })
+      pcall(function()
+        vim.api.nvim_win_close(winid, true)
+        vim.api.nvim_buf_delete(bufnr, { force = true })
+      end)
     end,
   })
   for _, k in ipairs { "<Esc>", "q" } do
     vim.keymap.set("", k, function()
-      vim.api.nvim_exec_autocmds("FocusLost", { buffer = bufnr })
+      pcall(function()
+        vim.api.nvim_exec_autocmds("FocusLost", { buffer = bufnr })
+      end)
     end, { buffer = bufnr })
   end
 


### PR DESCRIPTION
Fix not enough room error displayed when executing a docker command in a terminal
  - It was caused by improperly closing telescope picker buffer
  - Fixed by closing it with a function provided by telescope
  
Also removed some redundant notifications