### PR TITLE
Clean up

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,6 @@ require("telescope").extensions.docker.containers(--[[opts...]])
 --require("telescope").extensions.docker.files(...)
 ```
 
-> **_NOTE_** The dockerfiles command is still experimental, so it
-> may be slow or not always work as expected.
-
 ## Changing docker environment
 
 A table of environment variables may be passed to the pickers:

--- a/lua/telescope/_extensions/docker/compose/picker.lua
+++ b/lua/telescope/_extensions/docker/compose/picker.lua
@@ -9,33 +9,14 @@ local name = "Docker compose files"
 
 local docker_compose_picker = function(options)
   options = options or {}
-  if not options.find_command then
-    if 1 ~= vim.fn.executable "rg" then
-      local args = { "--type", "f", "-e", "yml", "-e", "yaml" }
-      if 1 == vim.fn.executable "fd" then
-        options.find_command = { "fd", unpack(args) }
-      elseif 1 == vim.fn.executable "fdfind" then
-        options.find_command = { "fdfind", unpack(args) }
-      end
-    else
-      options.find_command = {
-        "rg",
-        "--files",
-        "-t",
-        "yaml",
-      }
-    end
-  end
-
-  if not options.find_command then
-    util.error "No suitable find command found. Please install fd, fdfind or rg."
-    return
-  end
   if options.hidden == nil then
     options.hidden = true
   end
   if options.no_ignore == nil then
     options.no_ignore = true
+  end
+  if options.search_file == nil then
+    options.search_file = "{*.yml,*.yaml}"
   end
   if options.file_ignore_patterns == nil then
     options.file_ignore_patterns = {

--- a/lua/telescope/_extensions/docker/compose/picker.lua
+++ b/lua/telescope/_extensions/docker/compose/picker.lua
@@ -1,6 +1,5 @@
 local mappings = require "telescope._extensions.docker.compose.mappings"
 local builtin = require "telescope.builtin"
-local util = require "telescope._extensions.docker.util"
 local action_state = require "telescope.actions.state"
 local State = require "telescope._extensions.docker.util.docker_state"
 

--- a/lua/telescope/_extensions/docker/containers/container.lua
+++ b/lua/telescope/_extensions/docker/containers/container.lua
@@ -1,5 +1,7 @@
 local util = require "telescope._extensions.docker.util"
----@class Container
+local Item = require "telescope._extensions.docker.util.item"
+
+---@class Container : Item
 ---@field ID string
 ---@field Command string
 ---@field Names string
@@ -13,9 +15,7 @@ local util = require "telescope._extensions.docker.util"
 ---@field Size string
 ---@field Ports string
 ---@field LocalVolumes string
----@field env table?
-local Container = {}
-Container.__index = Container
+local Container = Item:new()
 
 ---@param json string: A json string
 ---@return Container
@@ -29,24 +29,33 @@ function Container:new(json)
       container = vim.fn.json_decode(json)
     end)
   end
-  return setmetatable(container or {}, Container)
+  container = container or {}
+  setmetatable(container, self)
+  self.__index = self
+  return container
 end
+
+Container.fields = {
+  { name = "ID", key_hl = "Conditional", value_hl = "Number" },
+  { name = "Names", key_hl = "Conditional", value_hl = "String" },
+  { name = "Status", key_hl = "Conditional", value_hl = "Function" },
+  { name = "Command", key_hl = "Conditional", value_hl = "String" },
+  { name = "CreatedAt", key_hl = "Conditional", value_hl = "String" },
+  { name = "RunningFor", key_hl = "Conditional", value_hl = "String" },
+  { name = "Image", key_hl = "Conditional", value_hl = "Number" },
+  { name = "Size", key_hl = "Conditional", value_hl = "String" },
+  { name = "Ports", key_hl = "Conditional", value_hl = "Number" },
+  { name = "Networks", key_hl = "Conditional", value_hl = "String" },
+  { name = "LocalVolumes", key_hl = "Conditional", value_hl = "Number" },
+  { name = "Labels", key_hl = "Conditional", value_hl = "String" },
+}
 
 ---@return string[]
 function Container:represent()
   local lines = {}
-  table.insert(lines, "ID: " .. self.ID)
-  table.insert(lines, "Names: " .. self.Names)
-  table.insert(lines, "State: " .. self.State)
-  table.insert(lines, "Command: " .. self.Command)
-  table.insert(lines, "CreatedAt: " .. self.CreatedAt)
-  table.insert(lines, "RunningFor: " .. self.RunningFor)
-  table.insert(lines, "Image: " .. self.Image)
-  table.insert(lines, "Size: " .. self.Size)
-  table.insert(lines, "Ports: " .. self.Ports)
-  table.insert(lines, "Networks: " .. self.Networks)
-  table.insert(lines, "LocalVolumes: " .. self.LocalVolumes)
-  table.insert(lines, "Labels: " .. self.Labels)
+  for _, field in pairs(self.fields) do
+    table.insert(lines, string.format("%s: %s", field.name, self[field.name]))
+  end
 
   if self.env then
     table.insert(lines, "")

--- a/lua/telescope/_extensions/docker/containers/previewer.lua
+++ b/lua/telescope/_extensions/docker/containers/previewer.lua
@@ -1,5 +1,4 @@
 local previewers = require "telescope.previewers"
-local util = require "telescope._extensions.docker.util"
 
 local previewer = {}
 
@@ -16,22 +15,8 @@ function previewer.container_previewer()
   }
 end
 
----@param status table
----@param container Container
-local function display_container(status, container)
-  local lines = container:represent()
-  local buf = util.create_preview_buffer(lines)
-  if buf == nil or buf == -1 then
-    return
-  end
-  local ok, e = pcall(vim.api.nvim_win_set_buf, status.preview_win, buf)
-  if ok == false then
-    util.error(e)
-  end
-end
-
 preview_fn = function(self, entry, status)
-  display_container(status, entry.value)
+  entry.value:display(status, entry.value)
 
   self.status = status
   self.state = self.state or {}

--- a/lua/telescope/_extensions/docker/images/image.lua
+++ b/lua/telescope/_extensions/docker/images/image.lua
@@ -1,6 +1,7 @@
 local util = require "telescope._extensions.docker.util"
+local Item = require "telescope._extensions.docker.util.item"
 
----@class Image
+---@class Image : Item
 ---@field ID string
 ---@field Tag string
 ---@field Repository string
@@ -11,42 +12,41 @@ local util = require "telescope._extensions.docker.util"
 ---@field VirtualSize string
 ---@field UniqueSize string
 ---@field SharedSize string
-local Image = {}
-Image.__index = Image
+local Image = Item:new()
 
 ---@param json string: A json string
 ---@return Image
 function Image:new(json)
   json = util.preprocess_json(json)
-  local container
+  local image
   if vim.json.decode then
-    container = vim.json.decode(json)
+    image = vim.json.decode(json)
   else
     vim.schedule(function()
-      container = vim.fn.json_decode(json)
+      image = vim.fn.json_decode(json)
     end)
   end
-  return setmetatable(container or {}, Image)
-end
-
----@return string[]
-function Image:represent()
-  local lines = {}
-  table.insert(lines, "ID: " .. self.ID)
-  table.insert(lines, "Tag: " .. self.Tag)
-  table.insert(lines, "Repository: " .. self.Repository)
-  table.insert(lines, "CreatedAt: " .. self.CreatedAt)
-  table.insert(lines, "CreatedSince: " .. self.CreatedSince)
-  table.insert(lines, "Containers: " .. self.Containers)
-  table.insert(lines, "Digest: " .. self.Digest)
-  table.insert(lines, "VirtualSize: " .. self.VirtualSize)
-  table.insert(lines, "UniqueSize: " .. self.UniqueSize)
-  table.insert(lines, "SharedSize: " .. self.SharedSize)
-  return lines
+  image = image or {}
+  setmetatable(image, self)
+  self.__index = self
+  return image
 end
 
 function Image:name()
   return self.Repository .. ":" .. self.Tag
 end
+
+Image.fields = {
+  { name = "ID", key_hl = "Conditional", value_hl = "Number" },
+  { name = "Tag", key_hl = "Conditional", value_hl = "String" },
+  { name = "Repository", key_hl = "Conditional", value_hl = "String" },
+  { name = "CreatedAt", key_hl = "Conditional", value_hl = "String" },
+  { name = "CreatedSince", key_hl = "Conditional", value_hl = "String" },
+  { name = "Containers", key_hl = "Conditional", value_hl = "Number" },
+  { name = "Digest", key_hl = "Conditional", value_hl = "String" },
+  { name = "VirtualSize", key_hl = "Conditional", value_hl = "Number" },
+  { name = "UniqueSize", key_hl = "Conditional", value_hl = "Number" },
+  { name = "SharedSize", key_hl = "Conditional", value_hl = "Number" },
+}
 
 return Image

--- a/lua/telescope/_extensions/docker/images/previewer.lua
+++ b/lua/telescope/_extensions/docker/images/previewer.lua
@@ -1,5 +1,4 @@
 local previewers = require "telescope.previewers"
-local util = require "telescope._extensions.docker.util"
 
 local previewer = {}
 
@@ -16,22 +15,8 @@ function previewer.image_previewer()
   }
 end
 
----@param status table
----@param image Image
-local function display_image(status, image)
-  local lines = image:represent()
-  local buf = util.create_preview_buffer(lines)
-  if buf == nil or buf == -1 then
-    return
-  end
-  local ok, e = pcall(vim.api.nvim_win_set_buf, status.preview_win, buf)
-  if ok == false then
-    util.error(e)
-  end
-end
-
 preview_fn = function(self, entry, status)
-  display_image(status, entry.value)
+  entry.value:display(status)
 
   self.status = status
   self.state = self.state or {}

--- a/lua/telescope/_extensions/docker/util/docker_state.lua
+++ b/lua/telescope/_extensions/docker/util/docker_state.lua
@@ -291,6 +291,8 @@ function State:fetch_images(callback)
             if json:len() > 0 then
               json = string.sub(json, 2, #json - 1)
               local image = Image:new(json)
+              local env = self:get_env()
+              image.env = env
               if image:name() == "<none>:<none>" then
                 table.insert(unnamed_images, image)
               else

--- a/lua/telescope/_extensions/docker/util/init.lua
+++ b/lua/telescope/_extensions/docker/util/init.lua
@@ -101,23 +101,6 @@ function notify(lvl, ...)
   end)
 end
 
-function util.create_preview_buffer(lines)
-  local ok, b = pcall(function()
-    local buf = vim.api.nvim_create_buf(false, true)
-    pcall(vim.api.nvim_buf_set_lines, buf, 0, -1, false, lines)
-    pcall(vim.api.nvim_buf_set_option, buf, "buftype", "nofile")
-    pcall(vim.api.nvim_buf_set_option, buf, "bufhidden", "wipe")
-    pcall(vim.api.nvim_buf_set_option, buf, "syntax", "yaml")
-    pcall(vim.api.nvim_buf_set_option, buf, "filetype", "yaml")
-    return buf
-  end)
-  if not ok then
-    util.warn(b)
-    return -1
-  end
-  return b
-end
-
 --- Preprocess json string and remove double
 --- quotations and special quotations that may
 --- be outputted by docker on macOS

--- a/lua/telescope/_extensions/docker/util/item.lua
+++ b/lua/telescope/_extensions/docker/util/item.lua
@@ -1,0 +1,83 @@
+local util = require "telescope._extensions.docker.util"
+
+---@class HighlightField
+---@field name string
+---@field key_hl string
+---@field value_hl string
+
+---@class Item
+---@field fields HighlightField[]
+---@field env table?
+---@field name string
+local Item = {
+  fields = {},
+  env = {},
+}
+
+function Item:new()
+  local o = {}
+  setmetatable(o, self)
+  self.__index = self
+  return o
+end
+
+---@return string[]
+function Item:represent()
+  local lines = {}
+  for _, field in pairs(self.fields or {}) do
+    table.insert(lines, string.format("%s: %s", field.name, self[field.name]))
+  end
+
+  if type(self.env) == "table" and next(self.env) then
+    table.insert(lines, "")
+    for k, v in pairs(self.env) do
+      table.insert(lines, "# " .. k .. ": " .. v)
+    end
+  end
+  return lines
+end
+
+function Item:create_preview_buffer()
+  local ok, b = pcall(function()
+    local lines = self:represent()
+    local buf = vim.api.nvim_create_buf(false, true)
+    vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
+    pcall(vim.api.nvim_buf_set_option, buf, "buftype", "nofile")
+    pcall(vim.api.nvim_buf_set_option, buf, "bufhidden", "wipe")
+    local i = 0
+    for _, field in pairs(self.fields) do
+      local name = field.name
+      local n = vim.fn.strchars(name)
+      vim.api.nvim_buf_add_highlight(buf, 0, field.key_hl, i, 0, n)
+      vim.api.nvim_buf_add_highlight(buf, 0, field.value_hl, i, n, -1)
+      i = i + 1
+    end
+    i = i + 1
+    if self.env then
+      for _, _ in pairs(self.env) do
+        vim.api.nvim_buf_add_highlight(buf, 0, "Comment", i, 0, -1)
+        i = i + 1
+      end
+    end
+    return buf
+  end)
+  if not ok then
+    util.warn(b)
+    return -1
+  end
+  return b
+end
+
+---@param status table
+function Item:display(status)
+  local buf = self:create_preview_buffer()
+  if buf == nil or buf == -1 then
+    return
+  end
+  local ok, e = pcall(vim.api.nvim_win_set_buf, status.preview_win, buf)
+  if ok == false then
+    util.error(e)
+  end
+end
+
+return Item


### PR DESCRIPTION
- Clean up code for containers and images
- Update highlights for image and container previewer:
   - Do not set yaml filetype to avoid unwanted autocommands
   - Set custom highlights
- Update dockerfiles picker
  - instead of calling `:filetype detect` when loading potential dockerfiles, call `vim.filetype.detect`, to avoid unwanted autocommands
- Update docker compose picker
  - instead of rewriting the find command, set the `search_file` field to `{*.yml,*.yaml}`