### PR TITLE
Bugfix/no abort on no input

### DIFF
--- a/lua/telescope/_extensions/docker/compose/actions.lua
+++ b/lua/telescope/_extensions/docker/compose/actions.lua
@@ -25,9 +25,12 @@ end
 function __select_compose_file(file)
   local cmd = "docker-compose -f " .. file .. " "
 
-  local suffix = vim.fn.input(cmd)
-  if not suffix or suffix:len() == 0 then
-    util.info "Invalid docker compose command"
+  local suffix = vim.fn.input {
+    prompt = cmd,
+    default = "",
+    cancelreturn = "",
+  }
+  if type(suffix) ~= "string" or suffix:len() == 0 then
     return
   end
 

--- a/lua/telescope/_extensions/docker/containers/actions.lua
+++ b/lua/telescope/_extensions/docker/containers/actions.lua
@@ -252,8 +252,14 @@ function actions.rename(prompt_bufnr, ask_for_input)
   end
   local container = selection.value
   local binary = setup.get_option "binary" or "docker"
-  local cmd = binary .. " rename " .. container.ID .. " "
-  local rename = vim.fn.input(cmd)
+  local rename = vim.fn.input {
+    prompt = binary .. " rename " .. container.ID .. " ",
+    default = "",
+    cancelreturn = "",
+  }
+  if type(rename) ~= "string" or rename == "" then
+    return
+  end
   local args = {
     "rename",
     container.ID,
@@ -358,10 +364,12 @@ function actions.exec(prompt_bufnr, ask_for_input)
     return
   end
   local binary = setup.get_option "binary" or "docker"
-  local command = binary .. " exec -it " .. container.ID .. " "
-  local exec = vim.fn.input(command)
-  if not exec or exec:len() == 0 then
-    util.warn "Invalid command"
+  local exec = vim.fn.input {
+    prompt = binary .. " exec -it " .. container.ID .. " ",
+    default = "",
+    cancelreturn = "",
+  }
+  if type(exec) ~= "string" or exec:len() == 0 then
     return
   end
   local args = {

--- a/lua/telescope/_extensions/docker/images/actions.lua
+++ b/lua/telescope/_extensions/docker/images/actions.lua
@@ -144,8 +144,14 @@ function actions.retag(prompt_bufnr, ask_for_input)
   end
   local image = selection.value
   local binary = setup.get_option "binary" or "docker"
-  local cmd = binary .. " image tag " .. image:name() .. " "
-  local retag = vim.fn.input(cmd)
+  local retag = vim.fn.input {
+    prompt = binary .. " image tag " .. image:name() .. " ",
+    default = "",
+    cancelreturn = "",
+  }
+  if type(retag) ~= "string" or retag:len() == 0 then
+    return
+  end
   local args = {
     "image",
     "tag",
@@ -179,15 +185,9 @@ function actions.push(prompt_bufnr, ask_for_input)
   end
   local image = selection.value
   local args = { "push", image:name() }
-  picker.docker_state:docker_job {
-    item = image,
+  picker.docker_state:docker_command {
     args = args,
     ask_for_input = ask_for_input,
-    start_msg = "Pushing image: " .. image:name(),
-    end_msg = "Image " .. image:name() .. " pushed",
-    callback = function()
-      actions.refresh_picker(prompt_bufnr)
-    end,
   }
 end
 

--- a/lua/telescope/_extensions/docker/util/docker_state.lua
+++ b/lua/telescope/_extensions/docker/util/docker_state.lua
@@ -54,9 +54,11 @@ end
 ---@class DockerCommandOpts
 ---@field args string[]: Docker command arguments
 ---@field ask_for_input boolean: Whether to ask for input
----@field start_msg string?: Message to display at the start of the job
 ---@field cwd string?: Current working directory
 
+---Execute a docker command with the provided arguments in
+---a new terminal window.
+---
 ---@param opts DockerCommandOpts
 function State:docker_command(opts)
   opts = opts or {}
@@ -123,6 +125,8 @@ end
 ---@field end_msg string
 ---@field ask_for_input boolean
 
+---Execute an async docker command with the provided arguments.
+---
 ---@param opts DockerJobOpts
 function State:docker_job(opts)
   opts = opts or {}

--- a/lua/telescope/_extensions/docker/util/docker_state.lua
+++ b/lua/telescope/_extensions/docker/util/docker_state.lua
@@ -88,9 +88,6 @@ function State:docker_command(opts)
 
   self.locked = true
   local ok, e = pcall(function()
-    if type(opts.start_msg) == "string" then
-      util.info(opts.start_msg)
-    end
     if
       vim.api.nvim_buf_get_option(0, "filetype")
       == enum.TELESCOPE_PROMPT_FILETYPE


### PR DESCRIPTION
- Fix docker rename, image retag and docker-compose commands not aborting on no user input.

- Docker image push is now run in a terminal window rather than as an async job